### PR TITLE
Renaming to support new naming convention

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,22 +8,29 @@ pipeline:
     commands:
     - dapper ci
 
-  stage-binaries:
-    image: rancher/dapper:1.11.2
-    commands:
-    - cp -r ./bin/* ./package/
+  github-binary-publish-release:
+    image: plugins/github-release
+    files:
+    - bin/kontainer-engine-driver-example-*
+    checksum:
+    - sha256
+    secrets: [github_token]
     when:
       branch: master
       event: tag
+      ref:
+        exclude: [ refs/tags/*rc* ]
 
-
-  publish-image:
-    image: plugins/docker
-    dockerfile: package/Dockerfile
-    repo: rancher/kontainer-engine-example-driver
-    context: package/
-    tag: ${DRONE_TAG}
-    secrets: [docker_username, docker_password]
+  github-binary-publish-prerelease:
+    image: plugins/github-release
+    prerelease: true
+    files:
+    - bin/kontainer-engine-driver-example-*
+    checksum:
+    - sha256
+    secrets: [github_token]
     when:
       branch: master
       event: tag
+      ref:
+        include: [ refs/tags/*rc* ]

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -21,7 +21,7 @@ ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
 RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
 
 ENV DAPPER_ENV REPO TAG DRONE_TAG
-ENV DAPPER_SOURCE /go/src/github.com/rancher/kontainer-engine-example-driver/
+ENV DAPPER_SOURCE /go/src/github.com/rancher/kontainer-engine-driver-example/
 ENV DAPPER_OUTPUT ./bin ./dist
 ENV DAPPER_DOCKER_SOCKET true
 ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Kontainer Engine Example Driver
 
 ## Running
 
-`./bin/kontainer-engine-example-driver`
+`./bin/kontainer-engine-driver-example`
 
 ## License
 Copyright (c) 2018 [Rancher Labs, Inc.](http://rancher.com)

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,3 +1,3 @@
 FROM ubuntu:16.04
-COPY kontainer-engine-example-driver /usr/bin/
-CMD ["kontainer-engine-example-driver"]
+COPY kontainer-engine-driver-example /usr/bin/
+CMD ["kontainer-engine-driver-example"]

--- a/scripts/build
+++ b/scripts/build
@@ -8,11 +8,11 @@ cd $(dirname $0)/..
 mkdir -p bin
 [ "$(uname)" != "Darwin" ] && LINKFLAGS="-linkmode external -extldflags -static -s"
 
-CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/kontainer-engine-example-driver
+CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/kontainer-engine-driver-example
 echo built default
 for i in darwin linux
 do
     export GOOS=$i
-    go build -o bin/kontainer-engine-example-driver-$i
+    go build -o bin/kontainer-engine-driver-example-$i
     echo built $i
 done

--- a/scripts/package
+++ b/scripts/package
@@ -16,9 +16,9 @@ if echo $TAG | grep -q dirty; then
     TAG=dev
 fi
 
-cp ../bin/kontainer-engine-example-driver .
+cp ../bin/kontainer-engine-driver-example .
 
-IMAGE=${REPO}/kontainer-engine-example-driver:${TAG}
+IMAGE=${REPO}/kontainer-engine-driver-example:${TAG}
 docker build -t ${IMAGE} .
 echo ${IMAGE} > ../dist/images
 echo Built ${IMAGE}


### PR DESCRIPTION
This change renames the example driver to support the new kontainer engine
driver naming convention.  The new convention is
`kontainer-engine-driver-<<driver name>>-extra-info`.

Issue:
rancher/rancher#16842