### PR TITLE
 Update kontainer driver schemas

### DIFF
--- a/gke_driver.go
+++ b/gke_driver.go
@@ -263,6 +263,10 @@ func (d *Driver) GetDriverCreateOptions(ctx context.Context) (*types.DriverFlags
 			DefaultBool: true,
 		},
 	}
+	driverFlag.Options["special-testing-field"] = &types.Flag{
+		Type:  types.StringType,
+		Usage: "This field exists only on the example driver so we can test schema updates in Rancher.",
+	}
 	return &driverFlag, nil
 }
 


### PR DESCRIPTION
This change adds a special field to the driver for testing purposes. This
field does not serve any purpose except allowing us to test the upgrade path
for third-party drivers and ensure the schema updates appropriately.

Issue:
[rancher/rancher#17712](https://github.com/rancher/rancher/issues/17712)